### PR TITLE
[fix]: Refactor block/bullet hover to eliminate re-render

### DIFF
--- a/src/components/BlockDumbComp.js
+++ b/src/components/BlockDumbComp.js
@@ -123,60 +123,17 @@ export default class BlockDumbComp extends React.Component {
       opacity: isDragging ? 0 : 1,
       cursor: 'move',
       margin: '0px',
-      ':hover': {}
+      ':hover': {
+        boxSizing: 'border-box',
+        WebkitTapHighlightColor: 'rgba(0,0,0,0)',
+        boxShadow: '0 1px 6px rgba(0, 0, 0, 0.12), 0 1px 4px rgba(0, 0, 0, 0.24)'
+      }
     };
 
     return connectDragSource(connectDropTarget(
       <div style={blockDrag} key='block'>
 
-        {Radium.getState(this.state, 'block', ':hover') ? (
-          <Paper>
-            <div style={resumeThemes[currentTheme].blockDiv}>
-              <Editor style={resumeThemes[currentTheme].jobTitle}
-                      text={this.props.jobTitle || 'Title/Role/Degree'}
-                      options={{toolbar: false}}
-                      onBlur={e => this.props.handleUpdateLocalState(e, 'jobTitle', 'blocks', this.props.blockId)} />
-
-              <div style={resumeThemes[currentTheme].pipe}>
-                |
-              </div>
-
-              <Editor style={resumeThemes[currentTheme].companyName}
-                      text={this.props.companyName || 'Company/Project/School Name'}
-                      options={{toolbar: false}}
-                      onBlur={e => this.props.handleUpdateLocalState(e, 'companyName', 'blocks', this.props.blockId)} />
-
-              <div style={resumeThemes[currentTheme].pipe}>
-                |
-              </div>
-
-              <Editor style={resumeThemes[currentTheme].jobLocation}
-                      text={this.props.location || 'Location / Project URL'}
-                      options={{toolbar: false}}
-                      onBlur={e => this.props.handleUpdateLocalState(e, 'location', 'blocks', this.props.blockId)} />
-
-              <Editor style={resumeThemes[currentTheme].jobYear}
-                      text={this.props.years || 'Timespan, if applicable'}
-                      options={{toolbar: false}}
-                      onBlur={e => this.props.handleUpdateLocalState(e, 'jobYear', 'blocks', this.props.blockId)} />
-
-              {Radium.getState(this.state, 'block', ':hover') ? (
-                <img src={require('styles/assets/ic_remove_circle_outline_black_24px.svg')}
-                       onClick={e => this.hideBlock(e, this.props.blockId)} />
-                  ) : null}
-
-                <div className='bulletContainer' style={styles.bulletContainer}>
-                  {bulletCollection}
-                </div>
-
-              {Radium.getState(this.state, 'block', ':hover') ? (
-                <img src={require('styles/assets/ic_add_circle_outline_black_24px.svg')}
-                    onClick={e => this.addBullet(e, this.props.blockId)} />
-                  ) : null}
-            </div>
-          </Paper>
-
-          ) :
+        {Radium.getState(this.state, 'block', ':hover')}
 
           <div style={resumeThemes[currentTheme].blockDiv}>
             <Editor style={resumeThemes[currentTheme].jobTitle}
@@ -208,7 +165,6 @@ export default class BlockDumbComp extends React.Component {
                     onBlur={e => this.props.handleUpdateLocalState(e, 'jobYear', 'blocks', this.props.blockId)} />
 
             {Radium.getState(this.state, 'block', ':hover') ? (
-
               <img src={require('styles/assets/ic_remove_circle_outline_black_24px.svg')}
                      onClick={e => this.hideBlock(e, this.props.blockId)} />
                 ) : null}
@@ -221,7 +177,7 @@ export default class BlockDumbComp extends React.Component {
               <img src={require('styles/assets/ic_add_circle_outline_black_24px.svg')}
                   onClick={e => this.addBullet(e, this.props.blockId)} />
                 ) : null}
-          </div>}
+          </div>
       </div>
     ));
   }

--- a/src/components/Bullet.js
+++ b/src/components/Bullet.js
@@ -114,48 +114,34 @@ export default class Bullet extends React.Component {
       opacity: isDragging ? 0 : 1,
       cursor: 'default',
       width: '100%',
-      ':hover': {}
+      ':hover': {
+        boxSizing: 'border-box',
+        WebkitTapHighlightColor: 'rgba(0,0,0,0)',
+        boxShadow: '0 1px 6px rgba(0, 0, 0, 0.12), 0 1px 4px rgba(0, 0, 0, 0.24)'
+      }
     };
 
     return connectDragSource(connectDropTarget(
       <div style={bulletDrag} key='bullet'>
 
+      {Radium.getState(this.state, 'bullet', ':hover')}
+
+        <Editor style={styles.editorField}
+                text={this.props.text || '[new bullet point]'}
+                options={{ toolbar: false }}
+                onBlur={e => this.props.handleUpdateLocalState(e, 'text', 'bullets', bulletId, parentBlockId)} />
+
         {Radium.getState(this.state, 'bullet', ':hover') ? (
-          <Paper>
-            <Editor style={styles.editorField}
-                    text={this.props.text || '[new bullet point]'}
-                    options={{ toolbar: false }}
-                    onBlur={e => this.props.handleUpdateLocalState(e, 'text', 'bullets', bulletId, parentBlockId)} />
-
-            {Radium.getState(this.state, 'bullet', ':hover') ? (
-            <img src={require('styles/assets/ic_remove_circle_outline_black_24px.svg')}
+          <img src={require('styles/assets/ic_remove_circle_outline_black_24px.svg')}
                  onClick={e => this.hideBullet(e, bulletId)} />
-              ) : null}
+            ) : null}
 
-            {Radium.getState(this.state, 'bullet', ':hover') ? (
-            <img src={require('styles/assets/drag-vertical.png')} style={styles.handle} />
-              ) : null}
-          </Paper>
-
-              ) :
-
-          <div>
-            <Editor style={styles.editorField}
-                    text={this.props.text || '[new bullet point]'}
-                    options={{ toolbar: false }}
-                    onBlur={e => this.props.handleUpdateLocalState(e, 'text', 'bullets', bulletId, parentBlockId)} />
-
-            {Radium.getState(this.state, 'bullet', ':hover') ? (
-            <img src={require('styles/assets/ic_remove_circle_outline_black_24px.svg')}
-                 onClick={e => this.hideBullet(e, bulletId)} />
-              ) : null}
-
-            {Radium.getState(this.state, 'bullet', ':hover') ? (
-            <img src={require('styles/assets/drag-vertical.png')} style={styles.handle} />
-              ) : null}
-          </div>}
+        {Radium.getState(this.state, 'bullet', ':hover') ? (
+          <img src={require('styles/assets/drag-vertical.png')} style={styles.handle} />
+            ) : null}
 
       </div>
+
     ));
   }
 };


### PR DESCRIPTION
Previously, the component would re-render on mouse leave before saving state (edits to text fields). Now the hover style is simply applied to the component rather than doing any re-rendering.
