### PR TITLE
[fix]: Reloading previous resume flips all form validation to 'true' for better UI

### DIFF
--- a/src/actions/resumeActions.js
+++ b/src/actions/resumeActions.js
@@ -185,7 +185,7 @@ export function getResumeFromServerDBAsync (payload) { // rename to "serverupdat
         dispatch(updateResumeWithServerResponse(serverResponseJavascriptObject))
       })
       .then((action) => {
-        dispatch(serverIsSavingUpdate('resumeHeader.name of recieved Resume:' + JSON.stringify(action.payload.resumeHeader.name)))
+        dispatch(serverIsSavingUpdate('resumeHeader.name of recieved Resume:' + JSON.stringify(action.payload.resumeHeader.name)))  // FIXME: this line gives an error, cannot read property payload of undefined
       }); // TODO: this needs to eventually be a server response that has {text: 'successful save!'} added to the resume body object.
           // TODO: this needs error handling
   };

--- a/src/components/ResumeSavePrint.jsx
+++ b/src/components/ResumeSavePrint.jsx
@@ -28,7 +28,10 @@ export default class ResumeSavePrint extends React.Component {
       let wrappedForServer = Object.assign({}, this.props.resumeState);
       wrappedForServer.userID = this.props.userID;
       this.props.actions.getResumeFromServerDBAsync(wrappedForServer);
-      console.log('clicked LOAD btn in ResumeSavePrint')
+
+
+      _.map(this.props.validations, (validation, key) => this.props.validations[key] = true)
+      this.props.actions.enableSubmit('Resume');
     } else {
       alert('To load a resume, please signup above');
     }


### PR DESCRIPTION
As requested by Melody, this prevents the user from needing to touch every validated field before saving again. Form validation continues as usual once the user touches any field.
